### PR TITLE
Do not record mocks for specified scopes

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function (name, options) {
       var callback = (arguments.length === 2) ? arguments[1]: null;
       if (!has_fixtures) {
         var fixtures = nock.recorder.play(),
-            place_holders = options.place_holders
+            place_holders = options.place_holders;
 
         fixtures = removeExcludedScopeFromArray(fixtures, options.exclude_scope);
 


### PR DESCRIPTION
This PR adds an additional option (`exclude_scope`) that allows one or more scopes to be excluded from the mocking process. As it stands, all HTTP calls are mocked, including the ones to our local service that we are presumably testing!

As I mention in the commit, credit to @poetic who I have unceremoniously stolen the function from.

I obviously have no attachment to this code, so seeing a reimplementation that achieved the same thing would also be fine from my perspective if this is unsuitable for some reason - I do believe this functionality needs to exist, though.
